### PR TITLE
feat(promptpack): validate against vendored spec schema (fixes evals rejection)

### DIFF
--- a/packages/promptpack/pyproject.toml
+++ b/packages/promptpack/pyproject.toml
@@ -25,6 +25,7 @@ classifiers = [
 ]
 dependencies = [
     "pydantic>=2.0",
+    "jsonschema>=4.18",
 ]
 
 [project.optional-dependencies]

--- a/packages/promptpack/src/promptpack/parser.py
+++ b/packages/promptpack/src/promptpack/parser.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 
 from pydantic import ValidationError
 
+from promptpack.schema import get_validator
 from promptpack.types import PromptPack
 
 if TYPE_CHECKING:
@@ -67,6 +68,20 @@ def parse_promptpack_string(content: str) -> PromptPack:
         data = json.loads(content)
     except json.JSONDecodeError as e:
         raise PromptPackParseError(f"Invalid JSON: {e}") from e
+
+    # Authoritative validation against the vendored spec schema. This is the
+    # single source of truth: it accepts every spec-defined section (including
+    # extensions like evals, workflow, agents and skills), so a spec-valid pack
+    # is never rejected just because the typed models below don't cover it yet.
+    schema_errors = sorted(get_validator().iter_errors(data), key=lambda err: list(err.path))
+    if schema_errors:
+        errors = [
+            {"loc": list(err.absolute_path), "msg": err.message, "type": "schema"}
+            for err in schema_errors
+        ]
+        raise PromptPackParseError(
+            f"PromptPack validation failed: {len(errors)} error(s)", errors=errors
+        )
 
     try:
         return PromptPack.model_validate(data)

--- a/packages/promptpack/src/promptpack/schema.py
+++ b/packages/promptpack/src/promptpack/schema.py
@@ -1,0 +1,39 @@
+# Copyright 2025 Altaira Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""Access to the vendored PromptPack JSON Schema.
+
+The schema under ``schema/promptpack.schema.json`` is vendored from the
+canonical spec (``SCHEMA_URL``) so validation works offline and stays pinned to
+a known spec version. Refresh it with ``python scripts/sync_schema.py``.
+
+This schema — not the pydantic models in ``types`` — is the source of truth for
+what a valid pack is. The models are a typed view of the stable core; the spec
+schema accepts every spec-defined section (including extensions like evals,
+workflow, agents and skills), so the parser never rejects a spec-valid pack.
+"""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from importlib import resources
+from typing import Any
+
+from jsonschema import Draft202012Validator
+
+# Canonical source of truth for the vendored copy under schema/.
+SCHEMA_URL = "https://promptpack.org/schema/latest/promptpack.schema.json"
+
+
+@lru_cache(maxsize=1)
+def load_schema() -> dict[str, Any]:
+    """Return the vendored PromptPack JSON Schema as a dict."""
+    resource = resources.files("promptpack") / "schema" / "promptpack.schema.json"
+    return json.loads(resource.read_text(encoding="utf-8"))
+
+
+@lru_cache(maxsize=1)
+def get_validator() -> Draft202012Validator:
+    """Return a cached Draft 2020-12 validator built from the vendored schema."""
+    return Draft202012Validator(load_schema())

--- a/packages/promptpack/src/promptpack/schema/promptpack.schema.json
+++ b/packages/promptpack/src/promptpack/schema/promptpack.schema.json
@@ -1,0 +1,2239 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://promptpack.org/schema/latest/promptpack.schema.json",
+  "title": "PromptPack Specification",
+  "description": "Schema for packaging, testing, and running multi-prompt conversational systems with multimodal, workflow, agent, agent-loop, and skills support",
+  "version": "1.4.0",
+  "type": "object",
+  "required": [
+    "id",
+    "name",
+    "version",
+    "template_engine",
+    "prompts"
+  ],
+  "additionalProperties": false,
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "JSON Schema reference for validation and IDE support",
+      "default": "https://promptpack.org/schema/v1/promptpack.schema.json",
+      "examples": [
+        "https://promptpack.org/schema/v1/promptpack.schema.json"
+      ]
+    },
+    "id": {
+      "type": "string",
+      "description": "Unique identifier for the pack. Used for referencing and caching. Should be lowercase with hyphens.",
+      "pattern": "^[a-z][a-z0-9-]*$",
+      "minLength": 1,
+      "maxLength": 100,
+      "examples": [
+        "customer-support",
+        "sales-assistant",
+        "technical-help"
+      ]
+    },
+    "name": {
+      "type": "string",
+      "description": "Human-readable name for the pack. Displayed in UIs and documentation.",
+      "minLength": 1,
+      "maxLength": 200,
+      "examples": [
+        "Customer Support Pack",
+        "Sales Assistant",
+        "Technical Support"
+      ]
+    },
+    "version": {
+      "type": "string",
+      "description": "Pack version following Semantic Versioning 2.0.0 (MAJOR.MINOR.PATCH). Can optionally include 'v' prefix. Use MAJOR for breaking changes, MINOR for new features, PATCH for bug fixes. This version tracks the pack as a whole, while individual prompts can have independent versions.",
+      "pattern": "^v?(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+      "examples": [
+        "1.0.0",
+        "v2.1.3",
+        "1.0.0-alpha",
+        "2.0.0-beta.1+build.123"
+      ]
+    },
+    "description": {
+      "type": "string",
+      "description": "Detailed description of the pack's purpose, use cases, and contents. Supports markdown formatting.",
+      "maxLength": 5000,
+      "examples": [
+        "Complete customer support prompt pack with multiple task types for handling support, sales, and technical inquiries"
+      ]
+    },
+    "template_engine": {
+      "type": "object",
+      "description": "Template engine configuration shared across all prompts in the pack. Defines how variables are substituted and fragments are resolved.",
+      "required": [
+        "version",
+        "syntax"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "string",
+          "description": "Template engine version. Use 'v1' for the current stable version.",
+          "examples": [
+            "v1",
+            "v2"
+          ]
+        },
+        "syntax": {
+          "type": "string",
+          "description": "Variable substitution syntax pattern. Defines how variables appear in templates.",
+          "examples": [
+            "{{variable}}",
+            "${variable}",
+            "{variable}"
+          ]
+        },
+        "features": {
+          "type": "array",
+          "description": "Optional list of supported template features beyond basic substitution.",
+          "items": {
+            "type": "string",
+            "enum": [
+              "basic_substitution",
+              "fragments",
+              "conditionals",
+              "loops",
+              "filters"
+            ]
+          },
+          "examples": [
+            [
+              "basic_substitution",
+              "fragments"
+            ]
+          ]
+        }
+      }
+    },
+    "prompts": {
+      "type": "object",
+      "description": "Map of task_type to prompt configuration. Each key is a task type (e.g., 'support', 'sales') and each value is a complete prompt definition. A pack must contain at least one prompt.",
+      "minProperties": 1,
+      "additionalProperties": {
+        "$ref": "#/$defs/Prompt"
+      },
+      "examples": [
+        {
+          "support": {
+            "id": "support",
+            "name": "Support Bot",
+            "version": "1.0.0",
+            "system_template": "You are a helpful assistant."
+          }
+        }
+      ]
+    },
+    "fragments": {
+      "type": "object",
+      "description": "Shared template fragments that can be referenced by any prompt in the pack. Fragments are reusable text blocks resolved at compile time. Keys are fragment names, values are fragment content.",
+      "additionalProperties": {
+        "type": "string"
+      },
+      "examples": [
+        {
+          "customer_context": "Customer: {{customer_name}}\\nIssue: {{issue}}",
+          "greeting": "Hello! How can I help you today?"
+        }
+      ]
+    },
+    "tools": {
+      "type": "object",
+      "description": "Tool definitions that can be referenced by prompts. Tools enable the LLM to call external functions. Keys are tool names, values are tool specifications following the JSON Schema for function calling.",
+      "additionalProperties": {
+        "$ref": "#/$defs/Tool"
+      }
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Optional pack-level metadata for categorization, discovery, and operational planning.",
+      "additionalProperties": true,
+      "properties": {
+        "domain": {
+          "type": "string",
+          "description": "Domain or category for this pack",
+          "examples": [
+            "customer-service",
+            "healthcare",
+            "finance"
+          ]
+        },
+        "language": {
+          "type": "string",
+          "description": "Primary language code (ISO 639-1)",
+          "pattern": "^[a-z]{2}$",
+          "examples": [
+            "en",
+            "es",
+            "fr"
+          ]
+        },
+        "tags": {
+          "type": "array",
+          "description": "Tags for categorization and discovery",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "support",
+              "sales",
+              "technical"
+            ]
+          ]
+        },
+        "cost_estimate": {
+          "type": "object",
+          "description": "Cost estimation for using this pack",
+          "properties": {
+            "min_cost_usd": {
+              "type": "number",
+              "description": "Minimum cost per execution in USD",
+              "minimum": 0
+            },
+            "max_cost_usd": {
+              "type": "number",
+              "description": "Maximum cost per execution in USD",
+              "minimum": 0
+            },
+            "avg_cost_usd": {
+              "type": "number",
+              "description": "Average cost per execution in USD",
+              "minimum": 0
+            }
+          }
+        }
+      }
+    },
+    "compilation": {
+      "type": "object",
+      "description": "Information about when and how this pack was compiled. Generated automatically by the packc compiler.",
+      "required": [
+        "compiled_with",
+        "created_at",
+        "schema"
+      ],
+      "properties": {
+        "compiled_with": {
+          "type": "string",
+          "description": "Version of the packc compiler used to create this pack",
+          "examples": [
+            "packc-v0.1.0",
+            "packc-v1.2.3"
+          ]
+        },
+        "created_at": {
+          "type": "string",
+          "format": "date-time",
+          "description": "ISO 8601 timestamp when the pack was compiled",
+          "examples": [
+            "2025-10-31T12:00:00Z"
+          ]
+        },
+        "schema": {
+          "type": "string",
+          "description": "Pack format schema version used",
+          "examples": [
+            "v1",
+            "v2"
+          ]
+        },
+        "source": {
+          "type": "string",
+          "description": "Optional source configuration file path",
+          "examples": [
+            "arena.yaml",
+            "config/prompts.yaml"
+          ]
+        }
+      }
+    },
+    "evals": {
+      "type": "array",
+      "description": "Pack-level eval definitions that apply across all prompts. Useful for cross-cutting quality concerns like brand consistency or safety checks. Prompt-level evals with the same id override pack-level evals.",
+      "items": {
+        "$ref": "#/$defs/Eval"
+      }
+    },
+    "workflow": {
+      "$ref": "#/$defs/WorkflowConfig",
+      "description": "Workflow configuration defining a state machine over the pack's prompts. Each state references a prompt key and declares event-driven transitions."
+    },
+    "agents": {
+      "$ref": "#/$defs/AgentsConfig",
+      "description": "Agent configuration mapping prompts to A2A-compatible agent definitions. Enables multi-agent orchestration via the Agent-to-Agent protocol."
+    },
+    "skills": {
+      "type": "array",
+      "description": "Skill sources for progressive-disclosure knowledge loading. Each entry is either a string (path or package reference), a SkillPathSource object, or an InlineSkill object.",
+      "items": {
+        "$ref": "#/$defs/SkillSource"
+      }
+    }
+  },
+  "$defs": {
+    "Prompt": {
+      "type": "object",
+      "description": "A single prompt configuration within a pack. Each prompt represents a specific task type (e.g., 'support', 'sales') with its own template, variables, tools, and validation rules. Prompts within a pack can evolve independently with their own version numbers.",
+      "required": [
+        "id",
+        "name",
+        "version",
+        "system_template"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this prompt, typically matching the task_type key",
+          "pattern": "^[a-z][a-z0-9_-]*$",
+          "examples": [
+            "support",
+            "sales",
+            "technical_support"
+          ]
+        },
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this prompt",
+          "minLength": 1,
+          "examples": [
+            "Support Bot",
+            "Sales Assistant"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Detailed description of this prompt's purpose and behavior",
+          "examples": [
+            "General customer support assistant for handling inquiries"
+          ]
+        },
+        "version": {
+          "type": "string",
+          "description": "Prompt version following Semantic Versioning 2.0.0. Independent from pack version, allowing individual prompts to evolve separately.",
+          "pattern": "^v?(0|[1-9]\\d*)\\.(0|[1-9]\\d*)\\.(0|[1-9]\\d*)(?:-((?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*)(?:\\.(?:0|[1-9]\\d*|\\d*[a-zA-Z-][0-9a-zA-Z-]*))*))?(?:\\+([0-9a-zA-Z-]+(?:\\.[0-9a-zA-Z-]+)*))?$",
+          "examples": [
+            "1.0.0",
+            "v2.1.0",
+            "1.5.2-beta"
+          ]
+        },
+        "system_template": {
+          "type": "string",
+          "description": "The system prompt template. Use template syntax (e.g., {{variable}}) for variable substitution. This is the core instruction that guides the LLM's behavior.",
+          "minLength": 1,
+          "examples": [
+            "You are a {{role}} assistant for {{company}}.\\n\\nProvide helpful, professional support.",
+            "You are an expert in {{domain}}. Help users with {{task_description}}."
+          ]
+        },
+        "variables": {
+          "type": "array",
+          "description": "Variable definitions for this prompt. Variables are placeholders in the template that are replaced with actual values at runtime.",
+          "items": {
+            "$ref": "#/$defs/Variable"
+          }
+        },
+        "tools": {
+          "type": "array",
+          "description": "List of tool names that this prompt is allowed to use. Tools must be defined in the pack-level 'tools' object.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "lookup_order",
+              "create_ticket"
+            ],
+            [
+              "search_products",
+              "get_pricing"
+            ]
+          ]
+        },
+        "tool_policy": {
+          "$ref": "#/$defs/ToolPolicy",
+          "description": "Policy governing how tools can be used by this prompt"
+        },
+        "pipeline": {
+          "$ref": "#/$defs/PipelineConfig",
+          "description": "Pipeline configuration defining processing stages and middleware"
+        },
+        "parameters": {
+          "$ref": "#/$defs/Parameters",
+          "description": "LLM generation parameters like temperature and max_tokens"
+        },
+        "validators": {
+          "type": "array",
+          "description": "Validation rules (guardrails) applied to LLM responses",
+          "items": {
+            "$ref": "#/$defs/Validator"
+          }
+        },
+        "evals": {
+          "type": "array",
+          "description": "Eval definitions scoped to this prompt. These evals assess the quality of responses generated by this specific prompt. Prompt-level evals with the same id override pack-level evals.",
+          "items": {
+            "$ref": "#/$defs/Eval"
+          }
+        },
+        "tested_models": {
+          "type": "array",
+          "description": "Model testing results documenting which models have been tested with this prompt and their performance",
+          "items": {
+            "$ref": "#/$defs/TestedModel"
+          }
+        },
+        "model_overrides": {
+          "type": "object",
+          "description": "Model-specific template modifications. Keys are model names (e.g., 'claude-3-opus', 'gpt-4'), values are override configurations.",
+          "additionalProperties": {
+            "$ref": "#/$defs/ModelOverride"
+          }
+        },
+        "media": {
+          "$ref": "#/$defs/MediaConfig",
+          "description": "Multimodal content configuration for this prompt. Defines supported media types and validation rules."
+        }
+      }
+    },
+    "Variable": {
+      "type": "object",
+      "description": "A template variable definition with type information and validation rules. Variables are replaced with actual values when the prompt is rendered.",
+      "required": [
+        "name",
+        "type",
+        "required"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Variable name used in templates (e.g., {{name}})",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "examples": [
+            "role",
+            "company",
+            "customer_name"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Data type of the variable",
+          "examples": [
+            "string",
+            "number",
+            "boolean",
+            "object",
+            "array"
+          ]
+        },
+        "required": {
+          "type": "boolean",
+          "description": "Whether this variable must be provided. Required variables without values will cause an error."
+        },
+        "default": {
+          "description": "Default value used when variable is not provided. Cannot be set if required is true.",
+          "examples": [
+            "TechCo",
+            42,
+            true,
+            {
+              "key": "value"
+            }
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of the variable's purpose",
+          "examples": [
+            "The role of the assistant",
+            "Customer's account ID"
+          ]
+        },
+        "example": {
+          "description": "Example value showing expected format and content",
+          "examples": [
+            "support agent",
+            "12345",
+            "john@example.com"
+          ]
+        },
+        "validation": {
+          "type": "object",
+          "description": "Validation rules applied to the variable value at runtime",
+          "additionalProperties": false,
+          "properties": {
+            "pattern": {
+              "type": "string",
+              "description": "Regular expression pattern (for string types)",
+              "examples": [
+                "^[a-zA-Z\\\\s]+$",
+                "^\\\\d{5}$",
+                "^[a-z0-9._%+-]+@[a-z0-9.-]+\\\\.[a-z]{2,}$"
+              ]
+            },
+            "min_length": {
+              "type": "integer",
+              "description": "Minimum string length (for string types)",
+              "minimum": 0,
+              "examples": [
+                3,
+                10
+              ]
+            },
+            "max_length": {
+              "type": "integer",
+              "description": "Maximum string length (for string types)",
+              "minimum": 1,
+              "examples": [
+                50,
+                1000
+              ]
+            },
+            "minimum": {
+              "type": "number",
+              "description": "Minimum numeric value (for number types)",
+              "examples": [
+                0,
+                1,
+                100
+              ]
+            },
+            "maximum": {
+              "type": "number",
+              "description": "Maximum numeric value (for number types)",
+              "examples": [
+                100,
+                1000
+              ]
+            },
+            "enum": {
+              "type": "array",
+              "description": "List of allowed values",
+              "items": {},
+              "examples": [
+                [
+                  "low",
+                  "medium",
+                  "high"
+                ],
+                [
+                  1,
+                  2,
+                  3
+                ]
+              ]
+            }
+          }
+        },
+        "binding": {
+          "type": "object",
+          "description": "Declares how this variable is automatically populated from runtime context.",
+          "additionalProperties": false,
+          "properties": {
+            "kind": {
+              "type": "string",
+              "description": "The binding source kind.",
+              "examples": [
+                "context",
+                "session",
+                "env",
+                "header"
+              ]
+            },
+            "field": {
+              "type": "string",
+              "description": "The field name within the binding source to extract.",
+              "examples": [
+                "user_id",
+                "session_id",
+                "locale"
+              ]
+            },
+            "auto_populate": {
+              "type": "boolean",
+              "description": "Whether this variable is automatically populated at runtime without caller input.",
+              "default": false
+            },
+            "filter": {
+              "type": "string",
+              "description": "Optional filter expression applied to the bound value.",
+              "examples": [
+                "lowercase",
+                "trim"
+              ]
+            }
+          }
+        }
+      }
+    },
+    "Tool": {
+      "type": "object",
+      "description": "A tool definition following OpenAI's function calling format. Tools enable the LLM to call external functions to retrieve data or perform actions.",
+      "required": [
+        "name",
+        "description"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Tool name used for referencing and calling",
+          "pattern": "^[a-zA-Z_][a-zA-Z0-9_]*$",
+          "examples": [
+            "lookup_order",
+            "create_ticket",
+            "search_database"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Clear description of what the tool does. The LLM uses this to decide when to call the tool.",
+          "minLength": 1,
+          "examples": [
+            "Look up order details by order ID",
+            "Create a support ticket with title, description, and priority"
+          ]
+        },
+        "parameters": {
+          "type": "object",
+          "description": "JSON Schema defining the tool's parameters. Follows JSON Schema specification.",
+          "required": [
+            "type",
+            "properties"
+          ],
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": [
+                "object"
+              ],
+              "description": "Must be 'object' for tool parameters"
+            },
+            "properties": {
+              "type": "object",
+              "description": "Parameter definitions",
+              "additionalProperties": {
+                "type": "object"
+              }
+            },
+            "required": {
+              "type": "array",
+              "description": "List of required parameter names",
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      }
+    },
+    "ToolPolicy": {
+      "type": "object",
+      "description": "Governance policy for tool usage. Controls when and how tools can be called by the LLM.",
+      "additionalProperties": false,
+      "properties": {
+        "tool_choice": {
+          "type": "string",
+          "description": "'auto' lets the LLM decide when to use tools, 'required' forces tool use, 'none' disables tools",
+          "enum": [
+            "auto",
+            "required",
+            "none"
+          ],
+          "default": "auto",
+          "examples": [
+            "auto",
+            "required"
+          ]
+        },
+        "max_rounds": {
+          "type": "integer",
+          "description": "Maximum number of LLM → tool → LLM cycles allowed per turn",
+          "minimum": 1,
+          "default": 5,
+          "examples": [
+            3,
+            5,
+            10
+          ]
+        },
+        "max_tool_calls_per_turn": {
+          "type": "integer",
+          "description": "Maximum number of tool calls allowed in a single turn",
+          "minimum": 1,
+          "default": 10,
+          "examples": [
+            1,
+            5,
+            10
+          ]
+        },
+        "blocklist": {
+          "type": "array",
+          "description": "List of tool names that are not allowed for this prompt (overrides tools list)",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "dangerous_tool",
+              "delete_data"
+            ]
+          ]
+        }
+      }
+    },
+    "PipelineConfig": {
+      "type": "object",
+      "description": "Pipeline configuration defining the processing stages and middleware applied to prompts and responses",
+      "required": [
+        "stages"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "stages": {
+          "type": "array",
+          "description": "Ordered list of pipeline stages. Common stages: 'template', 'provider', 'validator'",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "template",
+              "provider",
+              "validator"
+            ]
+          ]
+        },
+        "middleware": {
+          "type": "array",
+          "description": "Middleware components with their configurations. Applied in order during pipeline execution.",
+          "items": {
+            "$ref": "#/$defs/MiddlewareConfig"
+          }
+        }
+      }
+    },
+    "MiddlewareConfig": {
+      "type": "object",
+      "description": "Configuration for a single middleware component in the pipeline",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Middleware type identifier",
+          "examples": [
+            "template",
+            "provider",
+            "validator",
+            "custom"
+          ]
+        },
+        "config": {
+          "type": "object",
+          "description": "Type-specific configuration for the middleware",
+          "additionalProperties": true
+        }
+      }
+    },
+    "Parameters": {
+      "type": "object",
+      "description": "LLM generation parameters controlling the model's behavior and output characteristics",
+      "additionalProperties": false,
+      "properties": {
+        "temperature": {
+          "type": "number",
+          "description": "Sampling temperature (0-2). Higher values make output more random, lower values more deterministic.",
+          "minimum": 0,
+          "maximum": 2,
+          "examples": [
+            0.7,
+            1.0
+          ]
+        },
+        "max_tokens": {
+          "type": "integer",
+          "description": "Maximum number of tokens to generate in the response",
+          "minimum": 1,
+          "examples": [
+            100,
+            1000,
+            4000
+          ]
+        },
+        "top_p": {
+          "type": "number",
+          "description": "Nucleus sampling parameter (0-1). Alternative to temperature for controlling randomness.",
+          "minimum": 0,
+          "maximum": 1,
+          "examples": [
+            0.9,
+            1.0
+          ]
+        },
+        "top_k": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "description": "Top-k sampling parameter. Limits to top K tokens. Null means no limit.",
+          "minimum": 1,
+          "examples": [
+            40,
+            100,
+            null
+          ]
+        },
+        "frequency_penalty": {
+          "type": "number",
+          "description": "Penalty for token frequency (-2 to 2). Positive values reduce repetition.",
+          "minimum": -2,
+          "maximum": 2,
+          "examples": [
+            0,
+            0.5
+          ]
+        },
+        "presence_penalty": {
+          "type": "number",
+          "description": "Penalty for token presence (-2 to 2). Positive values encourage new topics.",
+          "minimum": -2,
+          "maximum": 2,
+          "examples": [
+            0,
+            0.5
+          ]
+        }
+      }
+    },
+    "Validator": {
+      "type": "object",
+      "description": "A validation rule (guardrail) applied to LLM responses. Validators can check content, length, format, and other constraints to ensure response quality and safety.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "The validator type that determines how validation is performed. Not an enum — runtimes define and register their own validator types.",
+          "minLength": 1,
+          "examples": [
+            "banned_words",
+            "max_length",
+            "length",
+            "max_sentences",
+            "regex_match",
+            "sentiment",
+            "custom"
+          ]
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this validator is active. Allows temporarily disabling validators without removing them.",
+          "default": true
+        },
+        "message": {
+          "type": "string",
+          "description": "User-facing message returned when the validator blocks content.",
+          "examples": [
+            "Response contains banned words",
+            "Response exceeds maximum length"
+          ]
+        },
+        "fail_on_violation": {
+          "type": "boolean",
+          "description": "If true, validation failures cause an error. If false, violations are logged but allowed.",
+          "default": false
+        },
+        "params": {
+          "type": "object",
+          "description": "Validator-specific parameters",
+          "additionalProperties": true,
+          "examples": [
+            {
+              "words": [
+                "inappropriate",
+                "banned"
+              ]
+            },
+            {
+              "max_characters": 1000,
+              "max_tokens": 250
+            }
+          ]
+        }
+      }
+    },
+    "TestedModel": {
+      "type": "object",
+      "description": "Testing results for a specific model. Documents which models have been tested with this prompt and their performance metrics.",
+      "required": [
+        "provider",
+        "model",
+        "date"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "provider": {
+          "type": "string",
+          "description": "LLM provider name",
+          "examples": [
+            "openai",
+            "anthropic",
+            "azure",
+            "bedrock"
+          ]
+        },
+        "model": {
+          "type": "string",
+          "description": "Specific model identifier",
+          "examples": [
+            "gpt-4",
+            "gpt-3.5-turbo",
+            "claude-3-opus",
+            "claude-3-sonnet"
+          ]
+        },
+        "date": {
+          "type": "string",
+          "format": "date",
+          "description": "Date when the model was tested (YYYY-MM-DD)",
+          "examples": [
+            "2025-10-31",
+            "2025-12-01"
+          ]
+        },
+        "success_rate": {
+          "type": "number",
+          "description": "Success rate (0-1) from test runs",
+          "minimum": 0,
+          "maximum": 1,
+          "examples": [
+            0.95,
+            0.87
+          ]
+        },
+        "avg_tokens": {
+          "type": "number",
+          "description": "Average number of tokens used per response",
+          "minimum": 0,
+          "examples": [
+            150,
+            500
+          ]
+        },
+        "avg_cost": {
+          "type": "number",
+          "description": "Average cost per execution in USD",
+          "minimum": 0,
+          "examples": [
+            0.0045,
+            0.012
+          ]
+        },
+        "avg_latency_ms": {
+          "type": "number",
+          "description": "Average response latency in milliseconds",
+          "minimum": 0,
+          "examples": [
+            1200,
+            3500
+          ]
+        },
+        "notes": {
+          "type": "string",
+          "description": "Additional notes about model performance or observations"
+        }
+      }
+    },
+    "ModelOverride": {
+      "type": "object",
+      "description": "Model-specific template modifications. Allows customizing prompts for specific models without changing the base template.",
+      "additionalProperties": false,
+      "properties": {
+        "system_template_prefix": {
+          "type": "string",
+          "description": "Text prepended to the system template for this model",
+          "examples": [
+            "<thinking>\\n",
+            "[Task]\\n"
+          ]
+        },
+        "system_template_suffix": {
+          "type": "string",
+          "description": "Text appended to the system template for this model",
+          "examples": [
+            "\\n\\nBe concise and direct.",
+            "\\n</thinking>"
+          ]
+        },
+        "system_template": {
+          "type": "string",
+          "description": "Complete replacement system template for this model (overrides the base template entirely)"
+        },
+        "parameters": {
+          "$ref": "#/$defs/Parameters",
+          "description": "Model-specific parameter overrides"
+        }
+      }
+    },
+    "MediaConfig": {
+      "type": "object",
+      "description": "Configuration for multimodal content support. Defines which media types are supported and their validation rules. Well-known types (image, audio, video, document) have specific config schemas. Custom types use GenericMediaTypeConfig.",
+      "required": [
+        "enabled"
+      ],
+      "properties": {
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether multimodal content is enabled for this prompt"
+        },
+        "supported_types": {
+          "type": "array",
+          "description": "List of supported media types for this prompt. Common types include: image, audio, video, document, model3d, archive. Custom types are allowed - each type should have a corresponding configuration object (e.g., 'foo' type requires a 'foo' field with GenericMediaTypeConfig or a specific schema).",
+          "items": {
+            "type": "string",
+            "pattern": "^[a-z0-9_]+$"
+          },
+          "examples": [
+            [
+              "image"
+            ],
+            [
+              "image",
+              "audio"
+            ],
+            [
+              "image",
+              "audio",
+              "video"
+            ],
+            [
+              "document",
+              "image"
+            ],
+            [
+              "model3d",
+              "document"
+            ]
+          ]
+        },
+        "image": {
+          "$ref": "#/$defs/ImageConfig",
+          "description": "Image-specific configuration and constraints"
+        },
+        "audio": {
+          "$ref": "#/$defs/AudioConfig",
+          "description": "Audio-specific configuration and constraints"
+        },
+        "video": {
+          "$ref": "#/$defs/VideoConfig",
+          "description": "Video-specific configuration and constraints"
+        },
+        "document": {
+          "$ref": "#/$defs/DocumentConfig",
+          "description": "Document-specific configuration and constraints (PDFs, CAD files, spreadsheets, etc.)"
+        },
+        "examples": {
+          "type": "array",
+          "description": "Example multimodal messages showing how to use media with this prompt",
+          "items": {
+            "$ref": "#/$defs/MultimodalExample"
+          }
+        }
+      },
+      "additionalProperties": {
+        "oneOf": [
+          {
+            "$ref": "#/$defs/ImageConfig"
+          },
+          {
+            "$ref": "#/$defs/AudioConfig"
+          },
+          {
+            "$ref": "#/$defs/VideoConfig"
+          },
+          {
+            "$ref": "#/$defs/DocumentConfig"
+          },
+          {
+            "$ref": "#/$defs/GenericMediaTypeConfig"
+          }
+        ]
+      }
+    },
+    "ImageConfig": {
+      "type": "object",
+      "description": "Configuration and validation rules for image content",
+      "additionalProperties": false,
+      "properties": {
+        "max_size_mb": {
+          "type": "integer",
+          "description": "Maximum file size in megabytes",
+          "minimum": 1,
+          "examples": [
+            10,
+            20
+          ]
+        },
+        "allowed_formats": {
+          "type": "array",
+          "description": "List of allowed image formats",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "jpeg",
+              "png",
+              "webp"
+            ],
+            [
+              "jpeg",
+              "jpg",
+              "png",
+              "webp",
+              "gif",
+              "bmp"
+            ]
+          ]
+        },
+        "default_detail": {
+          "type": "string",
+          "description": "Default detail level for image processing. 'low' uses fewer tokens, 'high' provides more detail, 'auto' lets the model decide.",
+          "default": "auto",
+          "examples": [
+            "low",
+            "high",
+            "auto"
+          ]
+        },
+        "require_caption": {
+          "type": "boolean",
+          "description": "Whether image captions are required",
+          "default": false
+        },
+        "max_images_per_msg": {
+          "type": "integer",
+          "description": "Maximum number of images allowed per message",
+          "minimum": 1,
+          "examples": [
+            1,
+            5,
+            10
+          ]
+        }
+      }
+    },
+    "AudioConfig": {
+      "type": "object",
+      "description": "Configuration and validation rules for audio content",
+      "additionalProperties": false,
+      "properties": {
+        "max_size_mb": {
+          "type": "integer",
+          "description": "Maximum file size in megabytes",
+          "minimum": 1,
+          "examples": [
+            25,
+            50
+          ]
+        },
+        "allowed_formats": {
+          "type": "array",
+          "description": "List of allowed audio formats",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "mp3",
+              "wav",
+              "ogg"
+            ],
+            [
+              "mp3",
+              "wav",
+              "opus",
+              "flac",
+              "m4a",
+              "aac",
+              "ogg",
+              "webm"
+            ]
+          ]
+        },
+        "max_duration_sec": {
+          "type": "integer",
+          "description": "Maximum audio duration in seconds",
+          "minimum": 1,
+          "examples": [
+            300,
+            600
+          ]
+        },
+        "require_metadata": {
+          "type": "boolean",
+          "description": "Whether audio metadata (title, description) is required",
+          "default": false
+        }
+      }
+    },
+    "VideoConfig": {
+      "type": "object",
+      "description": "Configuration and validation rules for video content",
+      "additionalProperties": false,
+      "properties": {
+        "max_size_mb": {
+          "type": "integer",
+          "description": "Maximum file size in megabytes",
+          "minimum": 1,
+          "examples": [
+            100,
+            200
+          ]
+        },
+        "allowed_formats": {
+          "type": "array",
+          "description": "List of allowed video formats",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "mp4",
+              "webm"
+            ],
+            [
+              "mp4",
+              "webm",
+              "mov",
+              "avi",
+              "mkv",
+              "ogg"
+            ]
+          ]
+        },
+        "max_duration_sec": {
+          "type": "integer",
+          "description": "Maximum video duration in seconds",
+          "minimum": 1,
+          "examples": [
+            600,
+            1200
+          ]
+        },
+        "require_metadata": {
+          "type": "boolean",
+          "description": "Whether video metadata (title, description) is required",
+          "default": false
+        }
+      }
+    },
+    "DocumentConfig": {
+      "type": "object",
+      "description": "Configuration and validation rules for document content (PDFs, CAD files, spreadsheets, etc.)",
+      "additionalProperties": false,
+      "properties": {
+        "max_size_mb": {
+          "type": "integer",
+          "description": "Maximum file size in megabytes",
+          "minimum": 1,
+          "examples": [
+            50,
+            100
+          ]
+        },
+        "allowed_formats": {
+          "type": "array",
+          "description": "List of allowed document formats",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "pdf",
+              "docx"
+            ],
+            [
+              "pdf",
+              "step",
+              "dwg"
+            ],
+            [
+              "csv",
+              "xlsx",
+              "ods"
+            ]
+          ]
+        },
+        "max_pages": {
+          "type": "integer",
+          "description": "Maximum number of pages/sheets for paginated documents",
+          "minimum": 1,
+          "examples": [
+            50,
+            100
+          ]
+        },
+        "require_metadata": {
+          "type": "boolean",
+          "description": "Whether document metadata (title, author, description) is required",
+          "default": false
+        },
+        "extraction_mode": {
+          "type": "string",
+          "description": "How to extract content from documents. 'text' extracts text only, 'structured' preserves formatting, 'raw' keeps original binary format.",
+          "enum": [
+            "text",
+            "structured",
+            "raw"
+          ],
+          "default": "text",
+          "examples": [
+            "text",
+            "structured"
+          ]
+        }
+      }
+    },
+    "GenericMediaTypeConfig": {
+      "type": "object",
+      "description": "Generic configuration for custom media types. Use this for types not covered by specific configs (ImageConfig, AudioConfig, etc.). Provides common validation properties that apply to most media types.",
+      "additionalProperties": true,
+      "properties": {
+        "max_size_mb": {
+          "type": "integer",
+          "description": "Maximum file size in megabytes",
+          "minimum": 1,
+          "examples": [
+            10,
+            50,
+            100
+          ]
+        },
+        "allowed_formats": {
+          "type": "array",
+          "description": "List of allowed file formats/extensions",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "obj",
+              "fbx",
+              "gltf"
+            ],
+            [
+              "zip",
+              "tar"
+            ],
+            [
+              "stl",
+              "ply"
+            ]
+          ]
+        },
+        "require_metadata": {
+          "type": "boolean",
+          "description": "Whether metadata is required for this media type",
+          "default": false
+        },
+        "validation_params": {
+          "type": "object",
+          "description": "Custom validation parameters specific to this media type. Structure depends on the type.",
+          "additionalProperties": true,
+          "examples": [
+            {
+              "max_vertices": 100000,
+              "require_textures": false
+            },
+            {
+              "compression": "gzip",
+              "max_entries": 1000
+            }
+          ]
+        }
+      }
+    },
+    "MultimodalExample": {
+      "type": "object",
+      "description": "Example multimodal message demonstrating how to use media content with a prompt",
+      "required": [
+        "name",
+        "role",
+        "parts"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Name identifying this example",
+          "examples": [
+            "image-analysis",
+            "audio-transcription"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Description of what this example demonstrates"
+        },
+        "role": {
+          "type": "string",
+          "description": "Message role (typically 'user' or 'assistant')",
+          "enum": [
+            "user",
+            "assistant",
+            "system"
+          ],
+          "examples": [
+            "user"
+          ]
+        },
+        "parts": {
+          "type": "array",
+          "description": "Message content parts (text and/or media)",
+          "items": {
+            "$ref": "#/$defs/ContentPart"
+          },
+          "minItems": 1
+        }
+      }
+    },
+    "ContentPart": {
+      "type": "object",
+      "description": "A single content part within a multimodal message. Can be text or media.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "Type of content part. Common types include: text, image, audio, video, document. Custom types are allowed for extensibility.",
+          "pattern": "^[a-z0-9_]+$",
+          "examples": [
+            "text",
+            "image",
+            "audio",
+            "document"
+          ]
+        },
+        "text": {
+          "type": "string",
+          "description": "Text content (required when type is 'text')",
+          "examples": [
+            "What's in this image?",
+            "Describe the scene"
+          ]
+        },
+        "media": {
+          "$ref": "#/$defs/MediaReference",
+          "description": "Media reference (required when type is 'image', 'audio', or 'video')"
+        }
+      }
+    },
+    "MediaReference": {
+      "type": "object",
+      "description": "Reference to a media file. Supports three loading methods: file path, URL, or base64 data.",
+      "required": [
+        "mime_type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "file_path": {
+          "type": "string",
+          "description": "Path to media file (relative to pack or absolute). Validated at compile time.",
+          "examples": [
+            "images/photo.jpg",
+            "./media/audio.mp3"
+          ]
+        },
+        "url": {
+          "type": "string",
+          "format": "uri",
+          "description": "URL to media file. Must be publicly accessible or require authentication.",
+          "examples": [
+            "https://example.com/image.jpg",
+            "https://cdn.example.com/video.mp4"
+          ]
+        },
+        "base64": {
+          "type": "string",
+          "description": "Base64-encoded media data. Use for small files or when embedding is preferred.",
+          "examples": [
+            "iVBORw0KGgoAAAANSUhEUgAAAAUA..."
+          ]
+        },
+        "mime_type": {
+          "type": "string",
+          "description": "MIME type of the media file",
+          "examples": [
+            "image/jpeg",
+            "image/png",
+            "audio/mp3",
+            "video/mp4"
+          ]
+        },
+        "detail": {
+          "type": "string",
+          "description": "Detail level for image processing (images only). Overrides default_detail from ImageConfig.",
+          "enum": [
+            "low",
+            "high",
+            "auto"
+          ],
+          "examples": [
+            "high"
+          ]
+        },
+        "caption": {
+          "type": "string",
+          "description": "Caption or description for the media",
+          "examples": [
+            "Product photo",
+            "Customer's voice recording"
+          ]
+        }
+      }
+    },
+    "Eval": {
+      "type": "object",
+      "description": "An eval definition that declares how to assess LLM output quality. Evals run asynchronously and produce scores or metrics, unlike validators which run inline and block.",
+      "required": [
+        "id",
+        "type",
+        "trigger"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "Unique identifier for this eval within its scope (prompt-level or pack-level).",
+          "minLength": 1,
+          "examples": [
+            "tone-check",
+            "brand-consistency",
+            "json_format"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this eval measures and why it matters."
+        },
+        "type": {
+          "type": "string",
+          "description": "The assertion type that determines how this eval is executed. Not an enum — runtimes define and register their own types.",
+          "minLength": 1,
+          "examples": [
+            "llm_judge",
+            "cosine_similarity",
+            "regex",
+            "contains",
+            "json_valid"
+          ]
+        },
+        "trigger": {
+          "type": "string",
+          "description": "When this eval should be triggered.",
+          "examples": [
+            "every_turn",
+            "on_session_complete",
+            "on_conversation_complete",
+            "on_workflow_step",
+            "sample_turns",
+            "sample_sessions"
+          ]
+        },
+        "sample_percentage": {
+          "type": "number",
+          "description": "Percentage of turns or sessions to sample when trigger is sample_turns or sample_sessions. Ignored for other trigger types.",
+          "default": 5,
+          "minimum": 0,
+          "maximum": 100,
+          "examples": [
+            5,
+            10,
+            25,
+            50
+          ]
+        },
+        "enabled": {
+          "type": "boolean",
+          "description": "Whether this eval is active. Allows temporarily disabling evals without removing them.",
+          "default": true
+        },
+        "params": {
+          "type": "object",
+          "description": "Type-specific configuration for the eval. Structure depends on the eval type — runtimes interpret these based on the type field.",
+          "additionalProperties": true,
+          "examples": [
+            {
+              "judge_prompt": "Rate the response tone on a scale of 1-5 for professionalism.",
+              "model": "gpt-4o",
+              "passing_score": 4
+            },
+            {
+              "patterns": [
+                "hello",
+                "welcome"
+              ]
+            }
+          ]
+        },
+        "metric": {
+          "$ref": "#/$defs/MetricDef",
+          "description": "Prometheus-style metric declaration describing the output shape of this eval. Runtimes use this to expose results to monitoring systems."
+        },
+        "threshold": {
+          "type": "object",
+          "description": "Pass/fail threshold for the eval score.",
+          "additionalProperties": false,
+          "properties": {
+            "operator": {
+              "type": "string",
+              "description": "Comparison operator for the threshold.",
+              "examples": [
+                "gte",
+                "lte",
+                "gt",
+                "lt",
+                "eq"
+              ]
+            },
+            "value": {
+              "type": "number",
+              "description": "The threshold value to compare against.",
+              "examples": [
+                0.8,
+                4,
+                0.95
+              ]
+            }
+          }
+        },
+        "message": {
+          "type": "string",
+          "description": "Human-readable message describing the eval result or failure reason.",
+          "examples": [
+            "Tone score below threshold",
+            "Response failed brand consistency check"
+          ]
+        },
+        "when": {
+          "type": "object",
+          "description": "Conditional expression that determines whether this eval runs for a given turn or session.",
+          "additionalProperties": true,
+          "examples": [
+            {
+              "has_variable": "customer_tier"
+            },
+            {
+              "turn_count_gte": 3
+            }
+          ]
+        },
+        "groups": {
+          "type": "array",
+          "description": "Eval group tags for organizing and filtering evals.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "quality",
+              "tone"
+            ],
+            [
+              "safety",
+              "compliance"
+            ]
+          ]
+        }
+      }
+    },
+    "MetricDef": {
+      "type": "object",
+      "description": "Prometheus-style metric declaration associated with an eval. Controls how eval results are exposed as monitoring metrics.",
+      "required": [
+        "name",
+        "type"
+      ],
+      "additionalProperties": true,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Metric name. Should follow Prometheus naming conventions (snake_case, namespace prefix recommended).",
+          "pattern": "^[a-zA-Z_:][a-zA-Z0-9_:]*$",
+          "examples": [
+            "promptpack_tone_score",
+            "promptpack_brand_consistency",
+            "promptpack_json_valid"
+          ]
+        },
+        "type": {
+          "type": "string",
+          "description": "Prometheus metric type that describes the value semantics.",
+          "enum": [
+            "gauge",
+            "counter",
+            "histogram",
+            "boolean"
+          ]
+        },
+        "range": {
+          "type": "object",
+          "description": "Optional value bounds. Useful for gauge metrics with known ranges.",
+          "properties": {
+            "min": {
+              "type": "number",
+              "description": "Minimum expected value"
+            },
+            "max": {
+              "type": "number",
+              "description": "Maximum expected value"
+            }
+          }
+        }
+      }
+    },
+    "WorkflowConfig": {
+      "type": "object",
+      "description": "State-machine workflow over the pack's prompts. Defines an entry state and event-driven transitions between states, where each state references a prompt key.",
+      "required": [
+        "version",
+        "entry",
+        "states"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "type": "integer",
+          "description": "Workflow schema version. Use 1 for the current stable format.",
+          "minimum": 1,
+          "examples": [
+            1
+          ]
+        },
+        "entry": {
+          "type": "string",
+          "description": "Name of the initial state. Must match a key in the states object.",
+          "examples": [
+            "greeting",
+            "triage"
+          ]
+        },
+        "states": {
+          "type": "object",
+          "description": "Map of state name to state definition. Each state references a prompt and declares transitions.",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/WorkflowState"
+          }
+        },
+        "engine": {
+          "type": "object",
+          "description": "Optional runtime engine configuration for workflow execution. Hosts standardized fields like 'budget' for resource limits, alongside runtime-specific hints (timeout, concurrency, etc.).",
+          "properties": {
+            "budget": {
+              "$ref": "#/$defs/WorkflowBudget",
+              "description": "Resource budget for workflow execution. Provides safety limits to prevent unbounded loops."
+            }
+          },
+          "additionalProperties": true
+        }
+      }
+    },
+    "WorkflowState": {
+      "type": "object",
+      "description": "A single state in the workflow state machine. References a prompt task and declares event-driven transitions to other states. May be marked as terminal to indicate workflow completion, or guarded with max_visits to bound loop iterations.",
+      "required": [
+        "prompt_task"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "prompt_task": {
+          "type": "string",
+          "description": "Reference to a prompt key defined in the pack's prompts object.",
+          "examples": [
+            "support",
+            "sales",
+            "triage"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of this state's purpose."
+        },
+        "on_event": {
+          "type": "object",
+          "description": "Map of event name to target state name. When the named event fires, the workflow transitions to the target state.",
+          "additionalProperties": {
+            "type": "string"
+          },
+          "examples": [
+            {
+              "escalate": "human_handoff",
+              "resolved": "closing"
+            }
+          ]
+        },
+        "persistence": {
+          "type": "string",
+          "description": "Whether conversation context is kept (persistent) or reset (transient) on entry.",
+          "examples": [
+            "transient",
+            "persistent"
+          ]
+        },
+        "orchestration": {
+          "type": "string",
+          "description": "How this state is orchestrated: internal (runtime manages), external (caller manages), or hybrid.",
+          "examples": [
+            "internal",
+            "external",
+            "hybrid"
+          ]
+        },
+        "skills": {
+          "type": "string",
+          "description": "Skill filter for this workflow state. A path to a skill directory/file that scopes which skills are available in this state, or the literal 'none' to disable skills.",
+          "examples": [
+            "./skills/billing",
+            "none"
+          ]
+        },
+        "terminal": {
+          "type": "boolean",
+          "description": "If true, this state is a terminal state. The workflow completes after this state's prompt executes. Terminal states should not declare on_event transitions.",
+          "default": false,
+          "examples": [
+            true
+          ]
+        },
+        "max_visits": {
+          "type": "integer",
+          "description": "Maximum number of times this state can be entered during a single workflow execution. When the limit is reached, the workflow transitions to the state named in on_max_visits. If on_max_visits is not set, the workflow terminates.",
+          "minimum": 1,
+          "examples": [
+            5,
+            10,
+            20
+          ]
+        },
+        "on_max_visits": {
+          "type": "string",
+          "description": "Target state to transition to when max_visits is reached. Must reference a key in the states object. If omitted and max_visits is reached, the workflow terminates with a budget-exhausted status.",
+          "examples": [
+            "review",
+            "summarize",
+            "error_handler"
+          ]
+        },
+        "artifacts": {
+          "type": "object",
+          "description": "Named artifact slots for lightweight, structured metadata that flows across state visits. Artifacts should be pointers (commit SHAs, URIs), compact representations (schemas, summaries, diffs), or small structured results — not bulk data. Artifact values are available to the prompt as template variables under the 'artifacts' namespace (e.g., {{artifacts.commit_sha}}).",
+          "additionalProperties": {
+            "$ref": "#/$defs/ArtifactDef"
+          },
+          "examples": [
+            {
+              "commit_sha": {
+                "type": "text/plain",
+                "description": "Git commit of the latest generated code"
+              },
+              "test_report": {
+                "type": "application/json",
+                "description": "Structured test runner summary"
+              }
+            }
+          ]
+        }
+      }
+    },
+    "ArtifactDef": {
+      "type": "object",
+      "description": "Declares a named artifact slot for carrying lightweight, structured metadata across workflow state visits. Artifacts are typically pointers (commit SHAs, file paths, URIs), compact representations (schemas, summaries, diffs), or small structured results — not bulk data. Values are captured at each state transition, forming an observable trace that enables time-travel debugging and workflow audit. They persist across loop iterations and are accessible to prompts as template variables.",
+      "required": [
+        "type"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "type": {
+          "type": "string",
+          "description": "MIME type indicating the artifact's content type. Used by runtimes to determine serialization and presentation.",
+          "examples": [
+            "text/plain",
+            "application/json",
+            "text/markdown",
+            "text/x-python"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable description of what this artifact contains and how it's used."
+        },
+        "mode": {
+          "type": "string",
+          "description": "How the artifact is updated across visits. 'replace' overwrites the previous value on each visit. 'append' accumulates content across visits (e.g., a log). Defaults to 'replace'.",
+          "enum": [
+            "replace",
+            "append"
+          ],
+          "default": "replace",
+          "examples": [
+            "replace",
+            "append"
+          ]
+        }
+      }
+    },
+    "WorkflowBudget": {
+      "type": "object",
+      "description": "Resource budget for workflow execution. Provides a safety net to prevent unbounded loops. When any budget limit is reached, the workflow terminates with a budget-exhausted status. All fields are optional — omitting a field means no limit for that resource.",
+      "additionalProperties": false,
+      "properties": {
+        "max_total_visits": {
+          "type": "integer",
+          "description": "Maximum total state visits across all states in the workflow. This is a global safety net independent of per-state max_visits.",
+          "minimum": 1,
+          "examples": [
+            50,
+            100,
+            200
+          ]
+        },
+        "max_tool_calls": {
+          "type": "integer",
+          "description": "Maximum total tool calls across all states in the workflow.",
+          "minimum": 1,
+          "examples": [
+            100,
+            500
+          ]
+        },
+        "max_wall_time_sec": {
+          "type": "integer",
+          "description": "Maximum wall-clock time in seconds for the entire workflow execution.",
+          "minimum": 1,
+          "examples": [
+            300,
+            600,
+            3600
+          ]
+        }
+      }
+    },
+    "AgentsConfig": {
+      "type": "object",
+      "description": "Agent configuration that maps prompts to A2A-compatible agent definitions. Enables multi-agent orchestration via the Agent-to-Agent protocol.",
+      "required": [
+        "entry",
+        "members"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "entry": {
+          "type": "string",
+          "description": "Prompt key of the entry agent — the default agent that receives incoming requests.",
+          "examples": [
+            "triage",
+            "router",
+            "main"
+          ]
+        },
+        "members": {
+          "type": "object",
+          "description": "Map of prompt key to agent definition. Each key must match a prompt defined in the pack's prompts object.",
+          "minProperties": 1,
+          "additionalProperties": {
+            "$ref": "#/$defs/AgentDef"
+          }
+        }
+      }
+    },
+    "AgentDef": {
+      "type": "object",
+      "description": "Agent definition for a single prompt, providing A2A Agent Card metadata. Overrides or extends the prompt's own metadata for agent discovery.",
+      "additionalProperties": false,
+      "properties": {
+        "description": {
+          "type": "string",
+          "description": "Agent description published in the A2A Agent Card. Overrides the prompt's description if set."
+        },
+        "tags": {
+          "type": "array",
+          "description": "Discovery tags for the agent, used by A2A registries and routers.",
+          "items": {
+            "type": "string"
+          },
+          "examples": [
+            [
+              "support",
+              "billing"
+            ],
+            [
+              "sales",
+              "enterprise"
+            ]
+          ]
+        },
+        "input_modes": {
+          "type": "array",
+          "description": "MIME types the agent accepts as input. Defaults to [\"text/plain\"] if omitted.",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "text/plain"
+          ],
+          "examples": [
+            [
+              "text/plain"
+            ],
+            [
+              "text/plain",
+              "image/png"
+            ]
+          ]
+        },
+        "output_modes": {
+          "type": "array",
+          "description": "MIME types the agent can produce as output. Defaults to [\"text/plain\"] if omitted.",
+          "items": {
+            "type": "string"
+          },
+          "default": [
+            "text/plain"
+          ],
+          "examples": [
+            [
+              "text/plain"
+            ],
+            [
+              "text/plain",
+              "application/json"
+            ]
+          ]
+        }
+      }
+    },
+    "SkillSource": {
+      "oneOf": [
+        {
+          "type": "string",
+          "description": "Path to a skill directory/file or a package reference (e.g., './skills', '@acme/billing-skills')."
+        },
+        {
+          "$ref": "#/$defs/SkillPathSource"
+        },
+        {
+          "$ref": "#/$defs/InlineSkill"
+        }
+      ],
+      "description": "A skill source for progressive-disclosure knowledge loading. Can be a simple string path, a path object with preload config, or an inline skill definition."
+    },
+    "SkillPathSource": {
+      "type": "object",
+      "description": "A skill source with a path and optional preload configuration.",
+      "required": [
+        "path"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Path to a skill directory, file, or package reference.",
+          "examples": [
+            "./skills/billing",
+            "@acme/billing-skills"
+          ]
+        },
+        "preload": {
+          "type": "boolean",
+          "description": "If true, load this skill source eagerly at pack initialization rather than on demand.",
+          "default": false,
+          "examples": [
+            true,
+            false
+          ]
+        }
+      }
+    },
+    "InlineSkill": {
+      "type": "object",
+      "description": "A skill defined inline within the pack. Useful for small, pack-specific skills that don't warrant a separate file.",
+      "required": [
+        "name",
+        "description",
+        "instructions"
+      ],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Human-readable name for this skill.",
+          "minLength": 1,
+          "examples": [
+            "escalation-protocol",
+            "refund-policy"
+          ]
+        },
+        "description": {
+          "type": "string",
+          "description": "Brief description of what this skill provides.",
+          "minLength": 1,
+          "examples": [
+            "Steps for escalating unresolved customer issues"
+          ]
+        },
+        "instructions": {
+          "type": "string",
+          "description": "The skill's instructions or knowledge content. Loaded into the agent's context when the skill is activated.",
+          "minLength": 1,
+          "examples": [
+            "When a customer issue cannot be resolved within 3 exchanges:\n1. Acknowledge the complexity\n2. Collect case details\n3. Create an escalation ticket"
+          ]
+        }
+      }
+    }
+  },
+  "examples": [
+    {
+      "$schema": "https://promptpack.org/schema/v1/promptpack.schema.json",
+      "id": "customer-support",
+      "name": "Customer Support Pack",
+      "version": "1.0.0",
+      "description": "Complete customer support prompt pack with multiple task types",
+      "template_engine": {
+        "version": "v1",
+        "syntax": "{{variable}}",
+        "features": [
+          "basic_substitution",
+          "fragments"
+        ]
+      },
+      "prompts": {
+        "support": {
+          "id": "support",
+          "name": "Support Bot",
+          "description": "General customer support assistant",
+          "version": "1.0.0",
+          "system_template": "You are a {{role}} assistant for {{company}}.",
+          "variables": [
+            {
+              "name": "role",
+              "type": "string",
+              "required": true,
+              "description": "The role of the assistant",
+              "example": "support agent"
+            }
+          ],
+          "tools": [
+            "lookup_order"
+          ],
+          "parameters": {
+            "temperature": 0.7,
+            "max_tokens": 1500
+          }
+        }
+      },
+      "tools": {
+        "lookup_order": {
+          "name": "lookup_order",
+          "description": "Look up order details by order ID",
+          "parameters": {
+            "type": "object",
+            "properties": {
+              "order_id": {
+                "type": "string",
+                "description": "The order ID to look up"
+              }
+            },
+            "required": [
+              "order_id"
+            ]
+          }
+        }
+      }
+    },
+    {
+      "$schema": "https://promptpack.org/schema/v1/promptpack.schema.json",
+      "id": "image-analyzer",
+      "name": "Image Analysis Pack",
+      "version": "1.0.0",
+      "description": "Multimodal pack for analyzing images with vision models",
+      "template_engine": {
+        "version": "v1",
+        "syntax": "{{variable}}",
+        "features": [
+          "basic_substitution"
+        ]
+      },
+      "prompts": {
+        "analyze": {
+          "id": "analyze",
+          "name": "Image Analyzer",
+          "description": "Analyzes images and provides detailed descriptions",
+          "version": "1.0.0",
+          "system_template": "You are an expert image analyst. Provide detailed, accurate descriptions of images.",
+          "parameters": {
+            "temperature": 0.7,
+            "max_tokens": 1000
+          },
+          "media": {
+            "enabled": true,
+            "supported_types": [
+              "image"
+            ],
+            "image": {
+              "max_size_mb": 20,
+              "allowed_formats": [
+                "jpeg",
+                "png",
+                "webp"
+              ],
+              "default_detail": "high",
+              "max_images_per_msg": 5
+            },
+            "examples": [
+              {
+                "name": "simple-image-analysis",
+                "description": "Basic image analysis with a single photo",
+                "role": "user",
+                "parts": [
+                  {
+                    "type": "text",
+                    "text": "What's in this image?"
+                  },
+                  {
+                    "type": "image",
+                    "media": {
+                      "file_path": "examples/photo.jpg",
+                      "mime_type": "image/jpeg",
+                      "detail": "high",
+                      "caption": "Sample photo for analysis"
+                    }
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/packages/promptpack/src/promptpack/types.py
+++ b/packages/promptpack/src/promptpack/types.py
@@ -252,9 +252,16 @@ class MediaConfig(BaseModel):
 
 
 class Prompt(BaseModel):
-    """A single prompt configuration within a pack."""
+    """A single prompt configuration within a pack.
 
-    model_config = ConfigDict(extra="forbid")
+    Uses ``extra="ignore"`` so spec-defined extension sections (e.g. prompt-level
+    ``evals``) do not break typed construction — the vendored JSON Schema is the
+    authoritative validator (see ``promptpack.schema``). These models are a typed
+    view of the stable core; extension data is validated by the schema but not
+    surfaced here.
+    """
+
+    model_config = ConfigDict(extra="ignore")
 
     id: str = Field(..., pattern=r"^[a-z][a-z0-9_-]*$")
     name: str = Field(..., min_length=1)
@@ -329,9 +336,15 @@ class PackMetadata(BaseModel):
 
 
 class PromptPack(BaseModel):
-    """Top-level PromptPack container."""
+    """Top-level PromptPack container.
 
-    model_config = ConfigDict(extra="forbid")
+    Uses ``extra="ignore"`` so spec-defined extension sections (``evals``,
+    ``workflow``, ``agents``, ``skills``, …) do not break typed construction.
+    The vendored JSON Schema (see ``promptpack.schema``) is the authoritative
+    validator; these models are a typed view of the stable core.
+    """
+
+    model_config = ConfigDict(extra="ignore")
 
     schema_url: str | None = Field(default=None, alias="$schema")
     id: str = Field(..., pattern=r"^[a-z][a-z0-9-]*$", min_length=1, max_length=100)

--- a/packages/promptpack/tests/test_parser.py
+++ b/packages/promptpack/tests/test_parser.py
@@ -3,6 +3,7 @@
 
 """Tests for PromptPack parser."""
 
+import json
 from pathlib import Path
 
 import pytest
@@ -134,3 +135,29 @@ def test_variable_access(sample_pack_content: str) -> None:
     assert customer_var is not None
     assert customer_var.required is False
     assert customer_var.default == "Guest"
+
+
+def test_parse_pack_with_evals(sample_pack_content: str) -> None:
+    """A pack using the spec's evals extension (RFC-0006) must parse.
+
+    Evals are a runtime-interpreted, spec-defined extension. The parser
+    validates against the vendored PromptPack schema, which accepts them, so a
+    pack carrying pack- and prompt-level evals must not be rejected.
+    """
+    data = json.loads(sample_pack_content)
+    data["evals"] = [
+        {
+            "id": "brand-consistency",
+            "type": "regex",
+            "trigger": "on_session_complete",
+            "params": {"pattern": "Acme"},
+        }
+    ]
+    first_prompt = next(iter(data["prompts"]))
+    data["prompts"][first_prompt]["evals"] = [
+        {"id": "tone", "type": "llm_judge", "trigger": "every_turn"}
+    ]
+
+    pack = parse_promptpack_string(json.dumps(data))
+
+    assert pack.id == "customer-support"

--- a/scripts/sync_schema.py
+++ b/scripts/sync_schema.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+# Copyright 2025 Altaira Labs
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sync the vendored PromptPack JSON Schema from the canonical spec URL.
+
+The schema is the single source of truth for what a valid pack is. We vendor a
+copy into the package so validation works offline and is pinned to a known
+version; run this script to refresh that copy when the spec is updated:
+
+    python scripts/sync_schema.py            # fetch latest, write if changed
+    python scripts/sync_schema.py --check    # CI: fail if the vendored copy is stale
+
+The canonical URL is also recorded as promptpack.schema.SCHEMA_URL.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+import urllib.request
+from pathlib import Path
+
+SCHEMA_URL = "https://promptpack.org/schema/latest/promptpack.schema.json"
+VENDORED = (
+    Path(__file__).resolve().parents[1]
+    / "packages/promptpack/src/promptpack/schema/promptpack.schema.json"
+)
+
+
+def fetch() -> str:
+    with urllib.request.urlopen(SCHEMA_URL, timeout=30) as resp:  # noqa: S310 (trusted URL)
+        raw = resp.read().decode("utf-8")
+    # Round-trip so the vendored file is canonically formatted and we fail fast
+    # on a non-JSON response.
+    return json.dumps(json.loads(raw), indent=2, ensure_ascii=False) + "\n"
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Sync the vendored PromptPack JSON Schema.")
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Exit non-zero if the vendored schema differs from the published one.",
+    )
+    args = parser.parse_args()
+
+    upstream = fetch()
+    current = VENDORED.read_text(encoding="utf-8") if VENDORED.exists() else None
+
+    if args.check:
+        if current != upstream:
+            print(f"Vendored schema is stale. Run: python {Path(__file__).name}")
+            return 1
+        print("Vendored schema is up to date.")
+        return 0
+
+    if current == upstream:
+        print("Vendored schema already up to date.")
+        return 0
+
+    VENDORED.write_text(upstream, encoding="utf-8")
+    print(f"Synced schema -> {VENDORED}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fixes the PromptKit interop bug (AltairaLabs/PromptKit#1318): `promptpack` rejected any pack carrying an `evals` section because the parser used hand-written pydantic models with `extra="forbid"`. `evals` is a **spec-defined extension** (RFC-0006, *Implemented*) that `packc` emits — so valid packs failed to load. The models had also drifted behind the spec generally (no `workflow`/`agents`/`skills` either).

## Approach — spec schema as the source of truth

Rather than hand-add each missing section (and keep drifting), this re-points validation at the canonical schema:

- **Vendor** `schema/promptpack.schema.json`, synced from `https://promptpack.org/schema/latest/promptpack.schema.json`, and validate packs against it with `jsonschema` (Draft 2020-12). The spec schema accepts every spec-defined section, so a spec-valid pack is never rejected.
- **Relax** `PromptPack`/`Prompt` to `extra="ignore"`: the schema is now the authoritative gate; the pydantic models remain a typed view of the stable core and simply tolerate extension sections instead of re-encoding (and drifting from) the whole spec.
- **`scripts/sync_schema.py`** refreshes the vendored copy from the canonical URL (`--check` mode for a CI drift guard).

This is the same "don't hand-duplicate the spec" lesson applied on the PromptKit side — the spec stays the single source of truth, and new extensions never silently break loading again.

## Tests / verification
- New `test_parse_pack_with_evals` — a pack with pack- and prompt-level `evals` now parses.
- Full `promptpack` (61) and `promptpack-langchain` (71) suites pass; existing `sample.pack.json` is spec-valid, so the new jsonschema gate doesn't break anything.
- Built wheel confirmed to bundle `promptpack/schema/promptpack.schema.json`.
- `ruff check` / `ruff format --check` / `mypy` clean.

## Follow-up (separate)
- A CI drift-check step (`python scripts/sync_schema.py --check`) — left out here since it edits `.github/workflows`.
- #1312 (PyPI publish / README install) is handled separately.
