### PR TITLE
docs: fix install instructions — packages not on PyPI yet (#1312)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,8 +10,11 @@ This monorepo contains the following packages:
 
 Base library for parsing PromptPack JSON files. No framework dependencies.
 
+> **Note:** not yet published to PyPI — install from source until the first release.
+
 ```bash
-pip install promptpack
+# From source (until published to PyPI)
+pip install "git+https://github.com/AltairaLabs/promptpack-python.git#subdirectory=packages/promptpack"
 ```
 
 ```python
@@ -32,8 +35,11 @@ rendered = prompt.render({"role": "support agent", "company": "Acme"})
 
 LangChain integration for PromptPacks.
 
+> **Note:** not yet published to PyPI — install from source until the first release.
+
 ```bash
-pip install promptpack-langchain
+# From source (until published to PyPI)
+pip install "git+https://github.com/AltairaLabs/promptpack-python.git#subdirectory=packages/promptpack-langchain"
 ```
 
 ```python


### PR DESCRIPTION
## Summary

Closes the README half of AltairaLabs/PromptKit#1312: the README told users to `pip install promptpack` / `pip install promptpack-langchain`, but neither package is published to PyPI, so both fail.

## Change

Document the working **from-source** install (pip + git subdirectory) for both packages, and flag PyPI as pending until the first release. Honest and accurate for the current state.

## Out of scope (your call)

Actually publishing to PyPI needs a release/publish workflow **and** a one-time PyPI trusted-publisher (OIDC) setup on the project — external maintainer steps I can't complete here. Happy to draft that publish workflow + setup doc as a follow-up if you want `pip install promptpack` to work for real; it'd need merging via the GitHub UI (workflow scope) and the PyPI project configured.
