### PR TITLE
ci: PyPI publish workflow (trusted publishing) + RELEASING docs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,84 @@
+name: Publish
+
+# Publishes the packages to PyPI using trusted publishing (OIDC) — no API
+# tokens. Requires a one-time PyPI trusted-publisher setup per project; see
+# RELEASING.md.
+#
+# Triggers:
+#   - a published GitHub release  -> publishes both packages
+#   - manual run (workflow_dispatch) -> choose which package(s) to publish
+
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      package:
+        description: Which package(s) to publish
+        type: choice
+        default: both
+        options:
+          - both
+          - promptpack
+          - promptpack-langchain
+
+jobs:
+  publish-promptpack:
+    name: Publish promptpack
+    if: >-
+      github.event_name == 'release' ||
+      github.event.inputs.package == 'both' ||
+      github.event.inputs.package == 'promptpack'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/promptpack/
+    permissions:
+      id-token: write  # required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade build
+          python -m build packages/promptpack --outdir dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist
+
+  publish-promptpack-langchain:
+    name: Publish promptpack-langchain
+    if: >-
+      github.event_name == 'release' ||
+      github.event.inputs.package == 'both' ||
+      github.event.inputs.package == 'promptpack-langchain'
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/promptpack-langchain/
+    permissions:
+      id-token: write  # required for trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build distributions
+        run: |
+          python -m pip install --upgrade build
+          python -m build packages/promptpack-langchain --outdir dist
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: dist

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,51 @@
+# Releasing
+
+Packages are published to PyPI by `.github/workflows/publish.yml` using
+**trusted publishing** (PyPI's OIDC flow) — no API tokens are stored.
+
+This repo publishes two packages:
+
+| Package | PyPI project |
+|---------|--------------|
+| `packages/promptpack` | [`promptpack`](https://pypi.org/project/promptpack/) |
+| `packages/promptpack-langchain` | [`promptpack-langchain`](https://pypi.org/project/promptpack-langchain/) |
+
+## One-time setup (per PyPI project)
+
+Until this is done, the publish workflow will fail at the upload step.
+
+For **each** project (`promptpack` and `promptpack-langchain`):
+
+1. Create the project on PyPI (or pre-register it via a "pending" trusted
+   publisher if it doesn't exist yet).
+2. Go to the project's **Settings → Publishing → Add a trusted publisher**
+   (GitHub Actions) and enter:
+   - **Owner:** `AltairaLabs`
+   - **Repository:** `promptpack-python`
+   - **Workflow name:** `publish.yml`
+   - **Environment:** `pypi`
+3. In this repo, create a GitHub Actions **Environment** named `pypi`
+   (Settings → Environments). Add reviewers/branch protection if you want a
+   manual approval gate before each publish.
+
+Both jobs use the same workflow file and `pypi` environment, so both projects
+point their trusted publisher at the same coordinates.
+
+## Cutting a release
+
+1. Bump the version in the relevant `pyproject.toml`
+   (`packages/promptpack/pyproject.toml` and/or
+   `packages/promptpack-langchain/pyproject.toml`). They version independently.
+2. Refresh the vendored schema if the spec changed:
+   `python scripts/sync_schema.py`.
+3. Merge to `main`.
+4. Publish, either:
+   - **GitHub Release** — create a release; the workflow publishes **both**
+     packages, or
+   - **Manual** — Actions → *Publish* → *Run workflow*, and pick which
+     package(s) to publish.
+
+The workflow builds an sdist + wheel with `python -m build` and uploads via
+`pypa/gh-action-pypi-publish`. The wheel bundles the vendored
+`promptpack/schema/promptpack.schema.json`, so installed packages validate
+offline.


### PR DESCRIPTION
## Summary

Adds the publish path behind #1312 so `pip install promptpack` / `promptpack-langchain` can work for real.

- **`.github/workflows/publish.yml`** — publishes both packages to PyPI via **trusted publishing** (OIDC, no stored API tokens). Triggers on a published GitHub release (both packages) or `workflow_dispatch` (pick a package). Builds sdist+wheel with `python -m build` and uploads via `pypa/gh-action-pypi-publish`.
- **`RELEASING.md`** — the one-time per-project trusted-publisher setup and the release procedure.

## Before this can publish (one-time, maintainer)

Per `RELEASING.md`, for **each** PyPI project (`promptpack`, `promptpack-langchain`):
1. Add a GitHub Actions trusted publisher: owner `AltairaLabs`, repo `promptpack-python`, workflow `publish.yml`, environment `pypi`.
2. Create a repo Actions **Environment** named `pypi` (optionally with an approval gate).

Until that's done the upload step will fail — by design (no tokens).

## ⚠️ Merge note
This adds a file under `.github/workflows/`, so it can't be merged via the `gh` CLI (lacks the `workflow` scope) — please **merge it from the GitHub UI**.

Both packages verified to build locally (`python -m build`); the `promptpack` wheel bundles the vendored schema.
