### PR TITLE
ci: add SonarCloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,6 +95,16 @@ jobs:
           files: packages/promptpack/coverage-promptpack.xml,packages/promptpack-langchain/coverage-langchain.xml
           fail_ci_if_error: false
 
+      - name: Upload coverage for SonarCloud
+        if: matrix.python-version == '3.12'
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage
+          path: |
+            packages/promptpack/coverage-promptpack.xml
+            packages/promptpack-langchain/coverage-langchain.xml
+          retention-days: 1
+
   examples:
     name: Verify Examples
     runs-on: ubuntu-latest
@@ -124,3 +134,28 @@ jobs:
 
       - name: Run validation_example
         run: python examples/validation_example.py
+
+  sonar:
+    name: SonarCloud
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.actor != 'dependabot[bot]'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Download coverage
+        uses: actions/download-artifact@v4
+        with:
+          name: coverage
+          path: packages
+
+      - name: SonarCloud Scan
+        uses: SonarSource/sonarqube-scan-action@713881670b6b3676cda39549040e2d88c70d582e # v8.2.0
+        with:
+          # Fail the job when the quality gate fails (don't pass silently).
+          args: -Dsonar.qualitygate.wait=true
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.projectKey=AltairaLabs_promptpack-python
+sonar.organization=altairalabs
+
+sonar.sources=packages/promptpack/src,packages/promptpack-langchain/src
+sonar.tests=packages/promptpack/tests,packages/promptpack-langchain/tests
+sonar.python.version=3.10, 3.11, 3.12, 3.13
+sonar.python.coverage.reportPaths=packages/promptpack/coverage-promptpack.xml,packages/promptpack-langchain/coverage-langchain.xml
+
+sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Wires SonarCloud into CI for both packages.

- New `sonar` job (needs: test) downloads the pytest coverage artifact and runs the scan with `-Dsonar.qualitygate.wait=true` (fails on a failed gate, not silently).
- `sonar-project.properties`: projectKey `AltairaLabs_promptpack-python`, org `altairalabs`, sources + coverage report paths for promptpack + promptpack-langchain.
- Test job now uploads coverage as an artifact (alongside the existing codecov upload).
- `SONAR_TOKEN` is a repo secret; sonar job skipped for dependabot.

Once green on main I'll add `SonarCloud Analysis` to the branch ruleset's required checks.