### PR TITLE
ci: migrate CLA enforcement to in-repo action (off cla-assistant.io)

### DIFF
--- a/.github/workflows/cla.yml
+++ b/.github/workflows/cla.yml
@@ -1,0 +1,31 @@
+name: "CLA Assistant"
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [opened, closed, synchronize]
+
+permissions:
+  actions: write
+  contents: write
+  pull-requests: write
+  statuses: write
+
+jobs:
+  CLAAssistant:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "CLA Assistant"
+        if: (github.event.comment.body == 'recheck' || github.event.comment.body == 'I have read the CLA Document and I hereby sign the CLA') || github.event_name == 'pull_request_target'
+        uses: contributor-assistant/github-action@v2.6.1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PERSONAL_ACCESS_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}
+        with:
+          path-to-signatures: 'signatures/version1/cla.json'
+          path-to-document: 'https://gist.github.com/chaholl/acc8f1f6c38376d00a162351f566b93e'
+          remote-organization-name: 'AltairaLabs'
+          remote-repository-name: 'cla-signatures'
+          branch: 'main'
+          allowlist: 'dependabot[bot],*[bot]'


### PR DESCRIPTION
## Migrate CLA enforcement off the cla-assistant.io SaaS to an in-repo Action

Replaces the third-party `cla-assistant.io` status check (which had an outage that blocked merges org-wide) with the in-repo `contributor-assistant/github-action@v2.6.1`. Signatures are stored in the private central ledger `AltairaLabs/cla-signatures` (which we own — also our relicensing evidence). DCO enforcement is unchanged.

**Do not merge yet.** This PR is part of a coordinated rollout:
1. Org secret `PERSONAL_ACCESS_TOKEN` must be set first (the Action writes signatures cross-repo; `GITHUB_TOKEN` can't).
2. Validate signing + the posted status on one repo.
3. Then merge across all gated repos; reconcile the required status check; uninstall the cla-assistant.io GitHub App.

Signing UX is unchanged: comment **"I have read the CLA Document and I hereby sign the CLA"**. CLA doc: https://gist.github.com/chaholl/acc8f1f6c38376d00a162351f566b93e

Note: re-collect cutover — existing signers re-sign on their next PR; export the old cla-assistant.io ledger when it recovers to backfill.
